### PR TITLE
Feature/#10 motion replay제작

### DIFF
--- a/GyroData.xcodeproj/project.pbxproj
+++ b/GyroData.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		329E7EEB295B05D000537466 /* MotionRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329E7EEA295B05D000537466 /* MotionRecord.swift */; };
 		32B01338295A844B005C8750 /* GraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32B01337295A844B005C8750 /* GraphView.swift */; };
 		32B0133A295A871C005C8750 /* GraphViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32B01339295A871C005C8750 /* GraphViewModel.swift */; };
+		32FDB349295C18C80095F6A5 /* ReplayType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32FDB348295C18C80095F6A5 /* ReplayType.swift */; };
 		63F01BB528D44FC400C53A39 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F01BB428D44FC400C53A39 /* AppDelegate.swift */; };
 		63F01BB928D44FC400C53A39 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F01BB828D44FC400C53A39 /* ViewController.swift */; };
 		63F01BBE28D44FC500C53A39 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 63F01BBD28D44FC500C53A39 /* Assets.xcassets */; };
@@ -24,6 +25,7 @@
 		329E7EEA295B05D000537466 /* MotionRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MotionRecord.swift; sourceTree = "<group>"; };
 		32B01337295A844B005C8750 /* GraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphView.swift; sourceTree = "<group>"; };
 		32B01339295A871C005C8750 /* GraphViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphViewModel.swift; sourceTree = "<group>"; };
+		32FDB348295C18C80095F6A5 /* ReplayType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplayType.swift; sourceTree = "<group>"; };
 		63F01BB128D44FC400C53A39 /* GyroData.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GyroData.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		63F01BB428D44FC400C53A39 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		63F01BB828D44FC400C53A39 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -63,6 +65,7 @@
 			isa = PBXGroup;
 			children = (
 				63F01BB428D44FC400C53A39 /* AppDelegate.swift */,
+				32FDB348295C18C80095F6A5 /* ReplayType.swift */,
 				63F01BB828D44FC400C53A39 /* ViewController.swift */,
 				329E7EE6295B052D00537466 /* Coordinate.swift */,
 				329E7EE8295B058200537466 /* MotionMode.swift */,
@@ -148,6 +151,7 @@
 			files = (
 				329E7EE9295B058200537466 /* MotionMode.swift in Sources */,
 				32B0133A295A871C005C8750 /* GraphViewModel.swift in Sources */,
+				32FDB349295C18C80095F6A5 /* ReplayType.swift in Sources */,
 				329E7EEB295B05D000537466 /* MotionRecord.swift in Sources */,
 				63F01BB928D44FC400C53A39 /* ViewController.swift in Sources */,
 				63F01BB528D44FC400C53A39 /* AppDelegate.swift in Sources */,

--- a/GyroData.xcodeproj/project.pbxproj
+++ b/GyroData.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		32B01338295A844B005C8750 /* GraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32B01337295A844B005C8750 /* GraphView.swift */; };
 		32B0133A295A871C005C8750 /* GraphViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32B01339295A871C005C8750 /* GraphViewModel.swift */; };
 		32FDB349295C18C80095F6A5 /* ReplayType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32FDB348295C18C80095F6A5 /* ReplayType.swift */; };
+		32FDB34B295C18F20095F6A5 /* MotionReplayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32FDB34A295C18F20095F6A5 /* MotionReplayViewController.swift */; };
+		32FDB34D295C19B60095F6A5 /* MotionReplayViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32FDB34C295C19B60095F6A5 /* MotionReplayViewModel.swift */; };
 		63F01BB528D44FC400C53A39 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F01BB428D44FC400C53A39 /* AppDelegate.swift */; };
 		63F01BB928D44FC400C53A39 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F01BB828D44FC400C53A39 /* ViewController.swift */; };
 		63F01BBE28D44FC500C53A39 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 63F01BBD28D44FC500C53A39 /* Assets.xcassets */; };
@@ -26,6 +28,8 @@
 		32B01337295A844B005C8750 /* GraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphView.swift; sourceTree = "<group>"; };
 		32B01339295A871C005C8750 /* GraphViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphViewModel.swift; sourceTree = "<group>"; };
 		32FDB348295C18C80095F6A5 /* ReplayType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplayType.swift; sourceTree = "<group>"; };
+		32FDB34A295C18F20095F6A5 /* MotionReplayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MotionReplayViewController.swift; sourceTree = "<group>"; };
+		32FDB34C295C19B60095F6A5 /* MotionReplayViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MotionReplayViewModel.swift; sourceTree = "<group>"; };
 		63F01BB128D44FC400C53A39 /* GyroData.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GyroData.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		63F01BB428D44FC400C53A39 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		63F01BB828D44FC400C53A39 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -66,6 +70,8 @@
 			children = (
 				63F01BB428D44FC400C53A39 /* AppDelegate.swift */,
 				32FDB348295C18C80095F6A5 /* ReplayType.swift */,
+				32FDB34A295C18F20095F6A5 /* MotionReplayViewController.swift */,
+				32FDB34C295C19B60095F6A5 /* MotionReplayViewModel.swift */,
 				63F01BB828D44FC400C53A39 /* ViewController.swift */,
 				329E7EE6295B052D00537466 /* Coordinate.swift */,
 				329E7EE8295B058200537466 /* MotionMode.swift */,
@@ -149,8 +155,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				32FDB34B295C18F20095F6A5 /* MotionReplayViewController.swift in Sources */,
 				329E7EE9295B058200537466 /* MotionMode.swift in Sources */,
 				32B0133A295A871C005C8750 /* GraphViewModel.swift in Sources */,
+				32FDB34D295C19B60095F6A5 /* MotionReplayViewModel.swift in Sources */,
 				32FDB349295C18C80095F6A5 /* ReplayType.swift in Sources */,
 				329E7EEB295B05D000537466 /* MotionRecord.swift in Sources */,
 				63F01BB928D44FC400C53A39 /* ViewController.swift in Sources */,

--- a/GyroData/AppDelegate.swift
+++ b/GyroData/AppDelegate.swift
@@ -29,7 +29,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let record = MotionRecord(id: UUID(), startDate: Date(),
                                   msInterval: 10, motionMode: .accelerometer,
                                   coordinates: randomCoordinates)
-        let vc = MotionReplayViewController(replayType: .play, motionRecord: record)
+        let vc = MotionReplayViewController(replayType: .view, motionRecord: record)
 
         window = UIWindow(frame: UIScreen.main.bounds)
         window?.rootViewController = UINavigationController(rootViewController: vc)

--- a/GyroData/AppDelegate.swift
+++ b/GyroData/AppDelegate.swift
@@ -12,9 +12,27 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 var window: UIWindow?
 
+    var randomCoordinate: Coordiante {
+        return Coordiante(x: Double.random(in: -5...5), y: Double.random(in: -15...5), z: Double.random(in: -5...15))
+    }
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+
+
+        var randomCoordinates = [Coordiante]()
+        for _ in 0..<100 {
+            randomCoordinates.append(randomCoordinate)
+        }
+
+        let record = MotionRecord(id: UUID(),
+                                  startDate: Date(),
+                                  msInterval: 10,
+                                  motionMode: .accelerometer,
+                                  coordinates: randomCoordinates)
+
+        let vc = MotionReplayViewController(replayType: .play, motionRecord: record)
+
         window = UIWindow(frame: UIScreen.main.bounds)
-        window?.rootViewController = UINavigationController(rootViewController: ViewController())
+        window?.rootViewController = UINavigationController(rootViewController: vc)
         window?.makeKeyAndVisible()
         return true
     }

--- a/GyroData/AppDelegate.swift
+++ b/GyroData/AppDelegate.swift
@@ -10,11 +10,14 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-var window: UIWindow?
+    var window: UIWindow?
 
     var randomCoordinate: Coordiante {
-        return Coordiante(x: Double.random(in: -5...5), y: Double.random(in: -15...5), z: Double.random(in: -5...15))
+        return Coordiante(x: Double.random(in: -5000...5000),
+                          y: Double.random(in: -1500...5000),
+                          z: Double.random(in: -5000...1500))
     }
+
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
 
@@ -23,12 +26,9 @@ var window: UIWindow?
             randomCoordinates.append(randomCoordinate)
         }
 
-        let record = MotionRecord(id: UUID(),
-                                  startDate: Date(),
-                                  msInterval: 10,
-                                  motionMode: .accelerometer,
+        let record = MotionRecord(id: UUID(), startDate: Date(),
+                                  msInterval: 10, motionMode: .accelerometer,
                                   coordinates: randomCoordinates)
-
         let vc = MotionReplayViewController(replayType: .play, motionRecord: record)
 
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/GyroData/GraphView.swift
+++ b/GyroData/GraphView.swift
@@ -17,14 +17,14 @@ final class GraphView: UIView {
 
     private let blueLabel: UILabel = {
         let label = UILabel()
-        label.text = "y:0"
+        label.text = "z:0"
         label.textColor = UIColor.blue
         return label
     }()
 
     private let greenLabel: UILabel = {
         let label = UILabel()
-        label.text = "z:0"
+        label.text = "y:0"
         label.textColor = UIColor.green
         return label
     }()
@@ -78,11 +78,11 @@ final class GraphView: UIView {
             viewModel.pastValueForRed.append(value)
         case .blue:
             layer = blueLinesLayer
-            blueLabel.text = "y:\(value)"
+            blueLabel.text = "z:\(value)"
             viewModel.pastValueForBlue.append(value)
         case .green:
             layer = greenLinesLayer
-            greenLabel.text = "z:\(value)"
+            greenLabel.text = "y:\(value)"
             viewModel.pastValueForGreen.append(value)
         }
 
@@ -142,12 +142,12 @@ final class GraphView: UIView {
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
         NSLayoutConstraint.activate([
-            redLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
-            blueLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
-            greenLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
-            redLabel.topAnchor.constraint(equalTo: topAnchor),
-            blueLabel.topAnchor.constraint(equalTo: topAnchor),
-            greenLabel.topAnchor.constraint(equalTo: topAnchor)
+            redLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
+            greenLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            blueLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),
+            redLabel.topAnchor.constraint(equalTo: topAnchor, constant: 10),
+            blueLabel.topAnchor.constraint(equalTo: topAnchor, constant: 10),
+            greenLabel.topAnchor.constraint(equalTo: topAnchor, constant: 10)
         ])
     }
     

--- a/GyroData/GraphView.swift
+++ b/GyroData/GraphView.swift
@@ -48,6 +48,12 @@ final class GraphView: UIView {
         layout()
     }
 
+    init(xScale: CGFloat) {
+        super.init(frame: .zero)
+        viewModel.xScale = xScale
+        layout()
+    }
+
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         fatalError("init(coder:) has not been implemented")

--- a/GyroData/GraphView.swift
+++ b/GyroData/GraphView.swift
@@ -69,6 +69,7 @@ final class GraphView: UIView {
 
     func drawGraphFor1Hz(layerType: Layer, value: Double) {
         var layer: CAShapeLayer?
+        let value = CGFloat(Int(value))
 
         switch layerType {
         case .red:
@@ -192,7 +193,7 @@ final class GraphView: UIView {
         path.move(to: CGPoint(x: 0, y: bounds.midY))
         layer.path = path
 
-        layer.lineWidth = 5
+        layer.lineWidth = 2
         layer.strokeColor = color
         layer.fillColor = UIColor.clear.cgColor
         return layer

--- a/GyroData/GraphView.swift
+++ b/GyroData/GraphView.swift
@@ -69,20 +69,19 @@ final class GraphView: UIView {
 
     func drawGraphFor1Hz(layerType: Layer, value: Double) {
         var layer: CAShapeLayer?
-        let value = CGFloat(Int(value))
 
         switch layerType {
         case .red:
             layer = redLinesLayer
-            redLabel.text = "x:\(value)"
+            redLabel.text = "x:\(String(format:"%.0f", value))"
             viewModel.pastValueForRed.append(value)
         case .blue:
             layer = blueLinesLayer
-            blueLabel.text = "z:\(value)"
+            blueLabel.text = "z:\(String(format:"%.0f", value))"
             viewModel.pastValueForBlue.append(value)
         case .green:
             layer = greenLinesLayer
-            greenLabel.text = "y:\(value)"
+            greenLabel.text = "y:\(String(format:"%.0f", value))"
             viewModel.pastValueForGreen.append(value)
         }
 

--- a/GyroData/MotionReplayViewController.swift
+++ b/GyroData/MotionReplayViewController.swift
@@ -19,12 +19,10 @@ final class MotionReplayViewController: UIViewController {
         return label
     }()
     private var graphView: GraphView
-    private var didPlayStarted = false
 
     init(replayType: ReplayType, motionRecord: MotionRecord) {
         viewModel = MotionReplayViewModel(replayType: replayType, record: motionRecord)
         graphView = GraphView(xScale: CGFloat(motionRecord.coordinates.count))
-        graphView.translatesAutoresizingMaskIntoConstraints = false
         super.init(nibName: nil, bundle: nil)
     }
 

--- a/GyroData/MotionReplayViewController.swift
+++ b/GyroData/MotionReplayViewController.swift
@@ -8,29 +8,27 @@
 import UIKit
 
 final class MotionReplayViewController: UIViewController {
-    private var viewModel: MotionReplayViewModel?
+    private var viewModel: MotionReplayViewModel!
     private let dateLabel: UILabel = {
         let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
     private let typeLabel: UILabel = {
         let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
-    private let graphView: GraphView = {
-        let graph = GraphView()
-        graph.translatesAutoresizingMaskIntoConstraints = false
-        return graph
-    }()
+    private var graphView: GraphView
+    private var didPlayStarted = false
 
     init(replayType: ReplayType, motionRecord: MotionRecord) {
         viewModel = MotionReplayViewModel(replayType: replayType, record: motionRecord)
+        graphView = GraphView(xScale: CGFloat(motionRecord.coordinates.count))
+        graphView.translatesAutoresizingMaskIntoConstraints = false
         super.init(nibName: nil, bundle: nil)
     }
 
     required init?(coder: NSCoder) {
+        graphView = GraphView()
         super.init(coder: coder)
         fatalError("init(coder:) has not been implemented")
     }
@@ -42,8 +40,20 @@ final class MotionReplayViewController: UIViewController {
         setUpLabelContents()
     }
 
+    override func viewDidLayoutSubviews() {
+        switch viewModel.replayType {
+        case .play:
+            if !viewModel.didPlayStarted { playGraphView() }
+        case .view:
+            showFinishedGraphView()
+        }
+    }
+
     private func layout() {
-        [dateLabel, typeLabel, graphView].forEach { view.addSubview($0) }
+        [dateLabel, typeLabel, graphView].forEach {
+            view.addSubview($0)
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
 
         NSLayoutConstraint.activate([
             dateLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
@@ -60,6 +70,30 @@ final class MotionReplayViewController: UIViewController {
     private func setUpLabelContents() {
         dateLabel.text = viewModel?.record.startDate.description
         typeLabel.text = viewModel?.replayType.name
+    }
+
+    private func playGraphView() {
+        let record = viewModel.record
+        viewModel.didPlayStarted = true
+        var index = 0
+        Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { timer in
+            self.graphView.drawGraphFor1Hz(layerType: .red, value: record.coordinates[index].x)
+            self.graphView.drawGraphFor1Hz(layerType: .blue, value: record.coordinates[index].y)
+            self.graphView.drawGraphFor1Hz(layerType: .green, value: record.coordinates[index].z)
+            index += 1
+            if index >= record.coordinates.count {
+                timer.invalidate()
+            }
+        }
+    }
+
+    private func showFinishedGraphView() {
+        guard let record = viewModel?.record else { return }
+        record.coordinates.forEach { coordinate in
+            self.graphView.drawGraphFor1Hz(layerType: .red, value: coordinate.x)
+            self.graphView.drawGraphFor1Hz(layerType: .blue, value: coordinate.y)
+            self.graphView.drawGraphFor1Hz(layerType: .green, value: coordinate.z)
+        }
     }
 }
 

--- a/GyroData/MotionReplayViewController.swift
+++ b/GyroData/MotionReplayViewController.swift
@@ -23,7 +23,6 @@ final class MotionReplayViewController: UIViewController {
         let button = UIButton()
         button.tintColor = .black
         button.setImage(UIImage(systemName: "play.fill"), for: .normal)
-        button.setImage(UIImage(systemName: "stop.fill"), for: .selected)
         button.setPreferredSymbolConfiguration(UIImage.SymbolConfiguration(pointSize: 80), forImageIn: .normal)
         button.setPreferredSymbolConfiguration(UIImage.SymbolConfiguration(pointSize: 80), forImageIn: .selected)
         button.addTarget(self, action: #selector(playButtonTapped(_:)), for: .touchUpInside)

--- a/GyroData/MotionReplayViewController.swift
+++ b/GyroData/MotionReplayViewController.swift
@@ -21,7 +21,7 @@ final class MotionReplayViewController: UIViewController {
     private var graphView: GraphView
     private lazy var playButton: UIButton = {
         let button = UIButton()
-        button.tintColor = .black
+        button.tintColor = .label
         button.setImage(UIImage(systemName: "play.fill"), for: .normal)
         button.setPreferredSymbolConfiguration(UIImage.SymbolConfiguration(pointSize: 80), forImageIn: .normal)
         button.setPreferredSymbolConfiguration(UIImage.SymbolConfiguration(pointSize: 80), forImageIn: .selected)

--- a/GyroData/MotionReplayViewController.swift
+++ b/GyroData/MotionReplayViewController.swift
@@ -15,6 +15,7 @@ final class MotionReplayViewController: UIViewController {
     }()
     private let typeLabel: UILabel = {
         let label = UILabel()
+        label.font = UIFont.preferredFont(forTextStyle: .largeTitle)
         return label
     }()
     private var graphView: GraphView
@@ -38,6 +39,7 @@ final class MotionReplayViewController: UIViewController {
         view.backgroundColor = .systemBackground
         layout()
         setUpLabelContents()
+        setUpGraphViewLayer()
     }
 
     override func viewDidLayoutSubviews() {
@@ -56,20 +58,25 @@ final class MotionReplayViewController: UIViewController {
         }
 
         NSLayoutConstraint.activate([
-            dateLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            dateLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
             dateLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            typeLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            typeLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
             typeLabel.topAnchor.constraint(equalTo: dateLabel.bottomAnchor),
-            graphView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-            graphView.topAnchor.constraint(equalTo: typeLabel.bottomAnchor),
-            graphView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            graphView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
+            graphView.topAnchor.constraint(equalTo: typeLabel.bottomAnchor, constant: 20),
+            graphView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
             graphView.heightAnchor.constraint(equalTo: graphView.widthAnchor)
         ])
     }
 
     private func setUpLabelContents() {
-        dateLabel.text = viewModel?.record.startDate.description
+        dateLabel.text = viewModel?.record.startDate.toString()
         typeLabel.text = viewModel?.replayType.name
+    }
+
+    private func setUpGraphViewLayer() {
+        graphView.layer.borderColor = UIColor.black.cgColor
+        graphView.layer.borderWidth = 2
     }
 
     private func playGraphView() {
@@ -78,8 +85,8 @@ final class MotionReplayViewController: UIViewController {
         var index = 0
         Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { timer in
             self.graphView.drawGraphFor1Hz(layerType: .red, value: record.coordinates[index].x)
-            self.graphView.drawGraphFor1Hz(layerType: .blue, value: record.coordinates[index].y)
-            self.graphView.drawGraphFor1Hz(layerType: .green, value: record.coordinates[index].z)
+            self.graphView.drawGraphFor1Hz(layerType: .green, value: record.coordinates[index].y)
+            self.graphView.drawGraphFor1Hz(layerType: .blue, value: record.coordinates[index].z)
             index += 1
             if index >= record.coordinates.count {
                 timer.invalidate()
@@ -91,8 +98,8 @@ final class MotionReplayViewController: UIViewController {
         guard let record = viewModel?.record else { return }
         record.coordinates.forEach { coordinate in
             self.graphView.drawGraphFor1Hz(layerType: .red, value: coordinate.x)
-            self.graphView.drawGraphFor1Hz(layerType: .blue, value: coordinate.y)
-            self.graphView.drawGraphFor1Hz(layerType: .green, value: coordinate.z)
+            self.graphView.drawGraphFor1Hz(layerType: .green, value: coordinate.y)
+            self.graphView.drawGraphFor1Hz(layerType: .blue, value: coordinate.z)
         }
     }
 }
@@ -105,5 +112,13 @@ fileprivate extension ReplayType {
         case .play:
             return "Play"
         }
+    }
+}
+
+fileprivate extension Date {
+    func toString() -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy/MM/dd HH:mm:ss"
+        return dateFormatter.string(from: self)
     }
 }

--- a/GyroData/MotionReplayViewController.swift
+++ b/GyroData/MotionReplayViewController.swift
@@ -1,0 +1,75 @@
+//
+//  MotionReplayViewController.swift
+//  GyroData
+//
+//  Created by 천수현 on 2022/12/28.
+//
+
+import UIKit
+
+final class MotionReplayViewController: UIViewController {
+    private var viewModel: MotionReplayViewModel?
+    private let dateLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    private let typeLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    private let graphView: GraphView = {
+        let graph = GraphView()
+        graph.translatesAutoresizingMaskIntoConstraints = false
+        return graph
+    }()
+
+    init(replayType: ReplayType, motionRecord: MotionRecord) {
+        viewModel = MotionReplayViewModel(replayType: replayType, record: motionRecord)
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+        layout()
+        setUpLabelContents()
+    }
+
+    private func layout() {
+        [dateLabel, typeLabel, graphView].forEach { view.addSubview($0) }
+
+        NSLayoutConstraint.activate([
+            dateLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            dateLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            typeLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            typeLabel.topAnchor.constraint(equalTo: dateLabel.bottomAnchor),
+            graphView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            graphView.topAnchor.constraint(equalTo: typeLabel.bottomAnchor),
+            graphView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            graphView.heightAnchor.constraint(equalTo: graphView.widthAnchor)
+        ])
+    }
+
+    private func setUpLabelContents() {
+        dateLabel.text = viewModel?.record.startDate.description
+        typeLabel.text = viewModel?.replayType.name
+    }
+}
+
+fileprivate extension ReplayType {
+    var name: String {
+        switch self {
+        case .view:
+            return "View"
+        case .play:
+            return "Play"
+        }
+    }
+}

--- a/GyroData/MotionReplayViewController.swift
+++ b/GyroData/MotionReplayViewController.swift
@@ -32,6 +32,7 @@ final class MotionReplayViewController: UIViewController {
     private let timerLabel: UILabel = {
         let label = UILabel()
         label.text = "0.0"
+        label.font = UIFont.preferredFont(forTextStyle: .largeTitle)
         return label
     }()
     private var timer: DispatchSourceTimer = {
@@ -55,6 +56,7 @@ final class MotionReplayViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .systemBackground
+        setUpNavigationBar()
         layout()
         setUpLabelContents()
         setUpGraphViewLayer()
@@ -65,6 +67,11 @@ final class MotionReplayViewController: UIViewController {
             viewModel.didGraphViewStartedDrawing = true
             showFinishedGraphView()
         }
+    }
+
+    private func setUpNavigationBar() {
+        navigationItem.title = "다시보기"
+        navigationItem.backButtonTitle = ""
     }
 
     private func layout() {

--- a/GyroData/MotionReplayViewModel.swift
+++ b/GyroData/MotionReplayViewModel.swift
@@ -10,10 +10,18 @@ import Foundation
 final class MotionReplayViewModel {
     let replayType: ReplayType
     let record: MotionRecord
-    var didPlayStarted = false
+    var didGraphViewStartedDrawing = false
+    var playButtonState: PlayButtonState = .play
 
     init(replayType: ReplayType, record: MotionRecord) {
         self.replayType = replayType
         self.record = record
+    }
+}
+
+extension MotionReplayViewModel {
+    enum PlayButtonState {
+        case play
+        case stop
     }
 }

--- a/GyroData/MotionReplayViewModel.swift
+++ b/GyroData/MotionReplayViewModel.swift
@@ -1,0 +1,18 @@
+//
+//  MotionReplayViewModel.swift
+//  GyroData
+//
+//  Created by 천수현 on 2022/12/28.
+//
+
+import Foundation
+
+final class MotionReplayViewModel {
+    let replayType: ReplayType
+    let record: MotionRecord
+
+    init(replayType: ReplayType, record: MotionRecord) {
+        self.replayType = replayType
+        self.record = record
+    }
+}

--- a/GyroData/MotionReplayViewModel.swift
+++ b/GyroData/MotionReplayViewModel.swift
@@ -10,6 +10,7 @@ import Foundation
 final class MotionReplayViewModel {
     let replayType: ReplayType
     let record: MotionRecord
+    var didPlayStarted = false
 
     init(replayType: ReplayType, record: MotionRecord) {
         self.replayType = replayType

--- a/GyroData/ReplayType.swift
+++ b/GyroData/ReplayType.swift
@@ -1,0 +1,11 @@
+//
+//  ReplayType.swift
+//  GyroData
+//
+//  Created by 천수현 on 2022/12/28.
+//
+
+enum ReplayType {
+    case view
+    case play
+}


### PR DESCRIPTION
@aCafela-coffee 

## PR 요약

- MotionReplayViewController와 MotionReplayViewModel을 제작하였습니다.
- button의 image size를 조절하기 위해 setPreferredSymbolConfiguration을 사용하였습니다.
- timer의 경우 Timer type은 일시중지 후 다시 실행할 수 없기 때문에 DispatchSourceTimer를 사용했습니다.
- MotionReplayVC는 replayType에 따라 분기를 하고 motionRecord를 토대로 GraphView를 보여주므로 이 두개를 init시점에 인자로 받도록 하였습니다.



**viewDidLayoutSubviews()**

- auto layout에 의해 frame이 결정되는 시점은 viewDidLoad가 아닌 viewDidLayoutSubviews이기에 이 시점에 그래프를 그리는 작업을 진행했습니다. (view모드의 경우)
- viewDidLayoutSubviews는 life cycle동안 여러번 호출되므로, 이미 그래프가 그려졌는데 또다시 그래프를 그리는 메서드를 호출하지 않도록 viewModel의 didGraphViewStartedDrawing 변수를 통해 분기처리를 해주었습니다.



**playGraphView()**

- index를 통해 마지막 record까지 drawGraphFor1Hz를 호출했다면 그 뒤에는 suspend되도록 했습니다.
- time 변수를 통해 0.1초 간격으로 timer가 올라가도록 설정해주었습니다.
  - String(format) 메서드를 통해 출력값을 조정하였습니다.



**showFinishedGraphView()**

- View모드로 진입한 경우 완성된 그래프를 보여주어야 하므로 해당 메서드를 호출했습니다.



**playButton**

- 버튼이 눌리면 일시정지, 다시 누르면 이어서 재생하기 위한 로직들을 구현했습니다.



## Screenshot

**View 모드**
<img src = "https://user-images.githubusercontent.com/67148595/209797380-34080009-7357-445a-bddd-3d1bd494e674.png" width="50%" height="height 50%">

**Play 모드**
<img src = "https://user-images.githubusercontent.com/67148595/209797434-9244b3fa-2678-498a-ac61-aeef70445117.gif" width="50%" height="height 50%">



## 변경사항



#### Linked Issue

close #10 



