### PR TITLE
Feature/#18 두번째 화면 수정

### DIFF
--- a/GyroData/Data/MotionRecordingStorage.swift
+++ b/GyroData/Data/MotionRecordingStorage.swift
@@ -22,8 +22,9 @@ final class MotionRecordingStorage: MotionRecordingStorageProtocol {
 
             do {
                 try context.save()
+                completion(.success(Void()))
             } catch {
-                print(error)
+                completion(.failure(error))
             }
         }
     }

--- a/GyroData/Domain/UseCases/SaveMotionDataUseCase.swift
+++ b/GyroData/Domain/UseCases/SaveMotionDataUseCase.swift
@@ -18,7 +18,7 @@ final class SaveMotionDataUseCase {
             case .success:
                 completion(.success(()))
             case .failure(let error):
-                print(error)
+                completion(.failure(error))
             }
         }
     }

--- a/GyroData/Presentation/Graph/GraphView.swift
+++ b/GyroData/Presentation/Graph/GraphView.swift
@@ -104,6 +104,7 @@ final class GraphView: UIView {
     }
 
     private func resetViewModel() {
+        viewModel.yScale = 60
         viewModel.pastValueForRed.removeAll()
         viewModel.pastValueForBlue.removeAll()
         viewModel.pastValueForGreen.removeAll()

--- a/GyroData/Presentation/MotionRecording/MotionRecordingViewController.swift
+++ b/GyroData/Presentation/MotionRecording/MotionRecordingViewController.swift
@@ -78,8 +78,8 @@ final class MotionRecordingViewController: UIViewController {
                 switch result {
                 case .success():
                     self?.navigationController?.popViewController(animated: true)
-                case .failure(let error):
-                    let alert = UIAlertController(title: "저장 실패", message: error.localizedDescription, preferredStyle: .alert)
+                case .failure(_):
+                    let alert = UIAlertController(title: "저장 실패", message: nil, preferredStyle: .alert)
                     let alertAction = UIAlertAction(title: "확인", style: .default)
                     alert.addAction(alertAction)
                     self?.present(alert, animated: true)

--- a/GyroData/Presentation/MotionRecording/MotionRecordingViewController.swift
+++ b/GyroData/Presentation/MotionRecording/MotionRecordingViewController.swift
@@ -39,6 +39,13 @@ final class MotionRecordingViewController: UIViewController {
         return segmentedControl
     }()
 
+    private lazy var activityIndicator = {
+        let indicator = UIActivityIndicatorView()
+        indicator.style = .large
+        indicator.isHidden = true
+        return indicator
+    }()
+
     private let graphView: GraphView = {
         let graphView = GraphView()
         graphView.layer.borderWidth = 2
@@ -59,6 +66,24 @@ final class MotionRecordingViewController: UIViewController {
                 self.recordButton.isEnabled = !isRecording
                 self.stopButton.isEnabled = isRecording
                 self.saveButton.isEnabled = self.motionRecordingViewModel.isSaveEnable
+            }
+        }
+        motionRecordingViewModel.saveRecordingCompletion = { [weak self] result in
+            DispatchQueue.main.async {
+                let stopActivityIndicator = {
+                    self?.activityIndicator.stopAnimating()
+                    self?.activityIndicator.isHidden = true
+                }
+                stopActivityIndicator()
+                switch result {
+                case .success():
+                    self?.navigationController?.popViewController(animated: true)
+                case .failure(let error):
+                    let alert = UIAlertController(title: "저장 실패", message: error.localizedDescription, preferredStyle: .alert)
+                    let alertAction = UIAlertAction(title: "확인", style: .default)
+                    alert.addAction(alertAction)
+                    self?.present(alert, animated: true)
+                }
             }
         }
     }
@@ -96,6 +121,13 @@ final class MotionRecordingViewController: UIViewController {
             self?.motionRecordingViewModel.stopButtonTapped()
         }
         let saveRecording = UIAction(title: "저장") { [weak self] _ in
+            let startActivityIndicator = {
+                DispatchQueue.main.async {
+                    self?.activityIndicator.isHidden = false
+                    self?.activityIndicator.startAnimating()
+                }
+            }
+            startActivityIndicator()
             self?.motionRecordingViewModel.saveRecord()
         }
         recordButton.addAction(startRecording, for: .touchUpInside)
@@ -131,6 +163,13 @@ final class MotionRecordingViewController: UIViewController {
             stackView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: spacing),
             stackView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -spacing),
             stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+        ])
+
+        view.addSubview(activityIndicator)
+        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            activityIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor)
         ])
     }
 }

--- a/GyroData/Presentation/MotionRecording/MotionRecordingViewModel.swift
+++ b/GyroData/Presentation/MotionRecording/MotionRecordingViewModel.swift
@@ -28,6 +28,7 @@ final class MotionRecordingViewModel {
         return !(isEmpty || isRecording)
     }
     var reflectRecordingState: ((Bool) -> Void)?
+    var saveRecordingCompletion: ((Result<Void, Error>) -> Void)?
     private let saveMotionDataUseCase = SaveMotionDataUseCase()
     private let timeOut = TimeInterval(60)
     private var startDate = Date()
@@ -55,8 +56,8 @@ final class MotionRecordingViewModel {
             motionMode: motionMode,
             coordinates: coordinates
         )
-        saveMotionDataUseCase.excute(record: motionRecord) { result in
-            print(result)
+        saveMotionDataUseCase.excute(record: motionRecord) { [weak self] result in
+            self?.saveRecordingCompletion?(result)
         }
     }
 


### PR DESCRIPTION
@Neph3779 

## PR 요약
둘째 화면의 요구사항들 반영

## Screenshot
|Activity Indicator|Alert|
|-----------------|-----|
|![activityIndicator](https://user-images.githubusercontent.com/70484506/209968402-d5ecfdba-408e-43c5-8029-44f9e23f316a.jpeg)|![alertError](https://user-images.githubusercontent.com/70484506/209968425-ef262bb0-8bd1-4924-ac0b-dd0fef66e00e.jpeg)|

## 변경사항
- 다시 측정하는 경우에는 GraphView의 y축 초기범위 초기화해주기 (upScale된 것 롤백)
- 데이터 저장 비동기로 진행하고 Activity Indicator 표시하기
- 저장 성공시 첫째 페이지로 이동, 저장 실패시 Indicator 닫고 첫째 페이지로 이동하지 않고 Alert에 실패이유 띄우기


#### Linked Issue
#18 
