### PR TITLE
Feature/#18 FileManager 통해 File 형식으로 저장 및 불러오기 기능 구현

### DIFF
--- a/GyroData.xcodeproj/project.pbxproj
+++ b/GyroData.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		329E7EED295B1A0100537466 /* MotionDataListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329E7EEC295B1A0100537466 /* MotionDataListViewController.swift */; };
 		32A17EF5295D8D6C007D8A8F /* SaveMotionDataUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A17EF4295D8D6C007D8A8F /* SaveMotionDataUseCase.swift */; };
 		32A17EF7295D8D77007D8A8F /* MotionRecordingStorageProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A17EF6295D8D77007D8A8F /* MotionRecordingStorageProtocol.swift */; };
+		32AA1E95295DBF0D002259C3 /* CoordinateDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AA1E94295DBF0D002259C3 /* CoordinateDTO.swift */; };
+		32AA1E97295DBF50002259C3 /* MotionRecordDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AA1E96295DBF50002259C3 /* MotionRecordDTO.swift */; };
 		32B01338295A844B005C8750 /* GraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32B01337295A844B005C8750 /* GraphView.swift */; };
 		32B0133A295A871C005C8750 /* GraphViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32B01339295A871C005C8750 /* GraphViewModel.swift */; };
 		32F77CC0295C7AA400A78CCD /* MotionData.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 32F77CBE295C7AA400A78CCD /* MotionData.xcdatamodeld */; };
@@ -44,6 +46,8 @@
 		329E7EEC295B1A0100537466 /* MotionDataListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MotionDataListViewController.swift; sourceTree = "<group>"; };
 		32A17EF4295D8D6C007D8A8F /* SaveMotionDataUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SaveMotionDataUseCase.swift; sourceTree = "<group>"; };
 		32A17EF6295D8D77007D8A8F /* MotionRecordingStorageProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MotionRecordingStorageProtocol.swift; sourceTree = "<group>"; };
+		32AA1E94295DBF0D002259C3 /* CoordinateDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinateDTO.swift; sourceTree = "<group>"; };
+		32AA1E96295DBF50002259C3 /* MotionRecordDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MotionRecordDTO.swift; sourceTree = "<group>"; };
 		32B01337295A844B005C8750 /* GraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphView.swift; sourceTree = "<group>"; };
 		32B01339295A871C005C8750 /* GraphViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphViewModel.swift; sourceTree = "<group>"; };
 		32F77CBF295C7AA400A78CCD /* MotionData.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = MotionData.xcdatamodel; sourceTree = "<group>"; };
@@ -117,6 +121,8 @@
 				32F77CBE295C7AA400A78CCD /* MotionData.xcdatamodeld */,
 				32F77CC1295C7BDA00A78CCD /* MotionRecordEntity+CoreDataClass.swift */,
 				32F77CC2295C7BDA00A78CCD /* MotionRecordEntity+CoreDataProperties.swift */,
+				32AA1E94295DBF0D002259C3 /* CoordinateDTO.swift */,
+				32AA1E96295DBF50002259C3 /* MotionRecordDTO.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -295,7 +301,9 @@
 				329E7EED295B1A0100537466 /* MotionDataListViewController.swift in Sources */,
 				32FDB345295BE62A0095F6A5 /* DeleteMotionDataUseCase.swift in Sources */,
 				32FD288A295B2588006B6871 /* RecordTableViewCell.swift in Sources */,
+				32AA1E95295DBF0D002259C3 /* CoordinateDTO.swift in Sources */,
 				32B0133A295A871C005C8750 /* GraphViewModel.swift in Sources */,
+				32AA1E97295DBF50002259C3 /* MotionRecordDTO.swift in Sources */,
 				32F77CCA295C7DB700A78CCD /* CoreDataStorage.swift in Sources */,
 				32FDB34D295C19B60095F6A5 /* MotionReplayViewModel.swift in Sources */,
 				32FDB349295C18C80095F6A5 /* ReplayType.swift in Sources */,

--- a/GyroData.xcodeproj/project.pbxproj
+++ b/GyroData.xcodeproj/project.pbxproj
@@ -18,7 +18,10 @@
 		32AA1E97295DBF50002259C3 /* MotionRecordDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AA1E96295DBF50002259C3 /* MotionRecordDTO.swift */; };
 		32B01338295A844B005C8750 /* GraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32B01337295A844B005C8750 /* GraphView.swift */; };
 		32B0133A295A871C005C8750 /* GraphViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32B01339295A871C005C8750 /* GraphViewModel.swift */; };
+		32C20245295EB41400BCDCCB /* MotionReplayStorageProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32C20244295EB41400BCDCCB /* MotionReplayStorageProtocol.swift */; };
+		32C20247295EB4D900BCDCCB /* FetchMotionDataUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32C20246295EB4D900BCDCCB /* FetchMotionDataUseCase.swift */; };
 		32E5748F295DD5B100E297D9 /* FileStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32E5748E295DD5B100E297D9 /* FileStorage.swift */; };
+		32E57491295EB3FC00E297D9 /* MotionReplayStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32E57490295EB3FC00E297D9 /* MotionReplayStorage.swift */; };
 		32F77CC0295C7AA400A78CCD /* MotionData.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 32F77CBE295C7AA400A78CCD /* MotionData.xcdatamodeld */; };
 		32F77CC5295C7BDA00A78CCD /* MotionRecordEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F77CC1295C7BDA00A78CCD /* MotionRecordEntity+CoreDataClass.swift */; };
 		32F77CC6295C7BDA00A78CCD /* MotionRecordEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F77CC2295C7BDA00A78CCD /* MotionRecordEntity+CoreDataProperties.swift */; };
@@ -51,7 +54,10 @@
 		32AA1E96295DBF50002259C3 /* MotionRecordDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MotionRecordDTO.swift; sourceTree = "<group>"; };
 		32B01337295A844B005C8750 /* GraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphView.swift; sourceTree = "<group>"; };
 		32B01339295A871C005C8750 /* GraphViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphViewModel.swift; sourceTree = "<group>"; };
+		32C20244295EB41400BCDCCB /* MotionReplayStorageProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MotionReplayStorageProtocol.swift; sourceTree = "<group>"; };
+		32C20246295EB4D900BCDCCB /* FetchMotionDataUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchMotionDataUseCase.swift; sourceTree = "<group>"; };
 		32E5748E295DD5B100E297D9 /* FileStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileStorage.swift; sourceTree = "<group>"; };
+		32E57490295EB3FC00E297D9 /* MotionReplayStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MotionReplayStorage.swift; sourceTree = "<group>"; };
 		32F77CBF295C7AA400A78CCD /* MotionData.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = MotionData.xcdatamodel; sourceTree = "<group>"; };
 		32F77CC1295C7BDA00A78CCD /* MotionRecordEntity+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MotionRecordEntity+CoreDataClass.swift"; sourceTree = "<group>"; };
 		32F77CC2295C7BDA00A78CCD /* MotionRecordEntity+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MotionRecordEntity+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -120,6 +126,7 @@
 				32F77CC9295C7DB700A78CCD /* CoreDataStorage.swift */,
 				32F77CCB295C81A800A78CCD /* MotionDataListStorage.swift */,
 				32040C0C295D696B00317CA8 /* MotionRecordingStorage.swift */,
+				32E57490295EB3FC00E297D9 /* MotionReplayStorage.swift */,
 				32F77CBE295C7AA400A78CCD /* MotionData.xcdatamodeld */,
 				32F77CC1295C7BDA00A78CCD /* MotionRecordEntity+CoreDataClass.swift */,
 				32F77CC2295C7BDA00A78CCD /* MotionRecordEntity+CoreDataProperties.swift */,
@@ -146,6 +153,7 @@
 			children = (
 				32A17EF6295D8D77007D8A8F /* MotionRecordingStorageProtocol.swift */,
 				32FD288F295BE4A6006B6871 /* MotionDataListStorageProtocol.swift */,
+				32C20244295EB41400BCDCCB /* MotionReplayStorageProtocol.swift */,
 			);
 			path = StorageInterfaces;
 			sourceTree = "<group>";
@@ -154,6 +162,7 @@
 			isa = PBXGroup;
 			children = (
 				32A17EF4295D8D6C007D8A8F /* SaveMotionDataUseCase.swift */,
+				32C20246295EB4D900BCDCCB /* FetchMotionDataUseCase.swift */,
 				32FD288D295BE44D006B6871 /* FetchMotionDataListUseCase.swift */,
 				32FDB344295BE62A0095F6A5 /* DeleteMotionDataUseCase.swift */,
 			);
@@ -309,6 +318,7 @@
 				32B0133A295A871C005C8750 /* GraphViewModel.swift in Sources */,
 				32AA1E97295DBF50002259C3 /* MotionRecordDTO.swift in Sources */,
 				32F77CCA295C7DB700A78CCD /* CoreDataStorage.swift in Sources */,
+				32C20245295EB41400BCDCCB /* MotionReplayStorageProtocol.swift in Sources */,
 				32FDB34D295C19B60095F6A5 /* MotionReplayViewModel.swift in Sources */,
 				32FDB349295C18C80095F6A5 /* ReplayType.swift in Sources */,
 				329E7EEB295B05D000537466 /* MotionRecord.swift in Sources */,
@@ -318,10 +328,12 @@
 				32FD288E295BE44D006B6871 /* FetchMotionDataListUseCase.swift in Sources */,
 				32FD288C295B2EFB006B6871 /* MotionDataListViewModel.swift in Sources */,
 				63F01BB528D44FC400C53A39 /* AppDelegate.swift in Sources */,
+				32C20247295EB4D900BCDCCB /* FetchMotionDataUseCase.swift in Sources */,
 				32A17EF7295D8D77007D8A8F /* MotionRecordingStorageProtocol.swift in Sources */,
 				329E7EE7295B052D00537466 /* Coordinate.swift in Sources */,
 				32A17EF5295D8D6C007D8A8F /* SaveMotionDataUseCase.swift in Sources */,
 				32B01338295A844B005C8750 /* GraphView.swift in Sources */,
+				32E57491295EB3FC00E297D9 /* MotionReplayStorage.swift in Sources */,
 				32040C0D295D696B00317CA8 /* MotionRecordingStorage.swift in Sources */,
 				32F77CC0295C7AA400A78CCD /* MotionData.xcdatamodeld in Sources */,
 				32F77CCC295C81A800A78CCD /* MotionDataListStorage.swift in Sources */,

--- a/GyroData.xcodeproj/project.pbxproj
+++ b/GyroData.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		32AA1E97295DBF50002259C3 /* MotionRecordDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AA1E96295DBF50002259C3 /* MotionRecordDTO.swift */; };
 		32B01338295A844B005C8750 /* GraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32B01337295A844B005C8750 /* GraphView.swift */; };
 		32B0133A295A871C005C8750 /* GraphViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32B01339295A871C005C8750 /* GraphViewModel.swift */; };
+		32E5748F295DD5B100E297D9 /* FileStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32E5748E295DD5B100E297D9 /* FileStorage.swift */; };
 		32F77CC0295C7AA400A78CCD /* MotionData.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 32F77CBE295C7AA400A78CCD /* MotionData.xcdatamodeld */; };
 		32F77CC5295C7BDA00A78CCD /* MotionRecordEntity+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F77CC1295C7BDA00A78CCD /* MotionRecordEntity+CoreDataClass.swift */; };
 		32F77CC6295C7BDA00A78CCD /* MotionRecordEntity+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F77CC2295C7BDA00A78CCD /* MotionRecordEntity+CoreDataProperties.swift */; };
@@ -50,6 +51,7 @@
 		32AA1E96295DBF50002259C3 /* MotionRecordDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MotionRecordDTO.swift; sourceTree = "<group>"; };
 		32B01337295A844B005C8750 /* GraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphView.swift; sourceTree = "<group>"; };
 		32B01339295A871C005C8750 /* GraphViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphViewModel.swift; sourceTree = "<group>"; };
+		32E5748E295DD5B100E297D9 /* FileStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileStorage.swift; sourceTree = "<group>"; };
 		32F77CBF295C7AA400A78CCD /* MotionData.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = MotionData.xcdatamodel; sourceTree = "<group>"; };
 		32F77CC1295C7BDA00A78CCD /* MotionRecordEntity+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MotionRecordEntity+CoreDataClass.swift"; sourceTree = "<group>"; };
 		32F77CC2295C7BDA00A78CCD /* MotionRecordEntity+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MotionRecordEntity+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -121,6 +123,7 @@
 				32F77CBE295C7AA400A78CCD /* MotionData.xcdatamodeld */,
 				32F77CC1295C7BDA00A78CCD /* MotionRecordEntity+CoreDataClass.swift */,
 				32F77CC2295C7BDA00A78CCD /* MotionRecordEntity+CoreDataProperties.swift */,
+				32E5748E295DD5B100E297D9 /* FileStorage.swift */,
 				32AA1E94295DBF0D002259C3 /* CoordinateDTO.swift */,
 				32AA1E96295DBF50002259C3 /* MotionRecordDTO.swift */,
 			);
@@ -297,6 +300,7 @@
 				3A6D2624295B258800FFD7F1 /* MotionRecordingViewController.swift in Sources */,
 				32FDB34B295C18F20095F6A5 /* MotionReplayViewController.swift in Sources */,
 				329E7EE9295B058200537466 /* MotionMode.swift in Sources */,
+				32E5748F295DD5B100E297D9 /* FileStorage.swift in Sources */,
 				32FD2890295BE4A6006B6871 /* MotionDataListStorageProtocol.swift in Sources */,
 				329E7EED295B1A0100537466 /* MotionDataListViewController.swift in Sources */,
 				32FDB345295BE62A0095F6A5 /* DeleteMotionDataUseCase.swift in Sources */,

--- a/GyroData/Application/AppDelegate.swift
+++ b/GyroData/Application/AppDelegate.swift
@@ -15,11 +15,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-//        saveDummyDataToCoreData()
         window = UIWindow(frame: UIScreen.main.bounds)
         window?.rootViewController = UINavigationController(rootViewController: MotionDataListViewController())
         window?.makeKeyAndVisible()
-
         return true
     }
 

--- a/GyroData/Application/AppDelegate.swift
+++ b/GyroData/Application/AppDelegate.swift
@@ -15,6 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+//        saveDummyDataToCoreData()
         window = UIWindow(frame: UIScreen.main.bounds)
         window?.rootViewController = UINavigationController(rootViewController: MotionDataListViewController())
         window?.makeKeyAndVisible()

--- a/GyroData/Data/CoordinateDTO.swift
+++ b/GyroData/Data/CoordinateDTO.swift
@@ -1,0 +1,12 @@
+//
+//  CoordinateDTO.swift
+//  GyroData
+//
+//  Created by 천수현 on 2022/12/29.
+//
+
+struct CoordinateDTO: Codable {
+    let x: Double
+    let y: Double
+    let z: Double
+}

--- a/GyroData/Data/FileStorage.swift
+++ b/GyroData/Data/FileStorage.swift
@@ -23,7 +23,6 @@ final class FileStorage {
 
     func saveFile(motionRecordData: MotionRecordDTO, completion: @escaping (Result<Void, Error>) -> Void) {
         // TODO: ios 16 분기처리 통해 deprecate된 메서드 사용 중지
-        let directoryURL = documentURL.appendingPathComponent("Gyro-Data")
         let fileURL = directoryURL.appendingPathComponent("\(motionRecordData.id).txt")
         guard let motionRecordJson = try? JSONEncoder().encode(motionRecordData),
               let data = String(data: motionRecordJson, encoding: .utf8) else { return }

--- a/GyroData/Data/FileStorage.swift
+++ b/GyroData/Data/FileStorage.swift
@@ -1,0 +1,71 @@
+//
+//  FileManager.swift
+//  GyroData
+//
+//  Created by 천수현 on 2022/12/29.
+//
+
+import Foundation
+
+final class FileStorage {
+    private let fileManager = FileManager.default
+    private lazy var documentURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+    private lazy var directoryURL = documentURL.appendingPathComponent("Gyro-Data")
+
+
+    init() {
+        if !UserDefaults.standard.bool(forKey: "isFirst") {
+            UserDefaults.standard.set(true, forKey: "isFirst")
+            makeDirectory()
+        }
+    }
+
+    func saveFile(motionRecordData: MotionRecordDTO, completion: @escaping (Result<Void, Error>) -> Void) {
+        // TODO: ios 16 분기처리 통해 deprecate된 메서드 사용 중지
+        let directoryURL = documentURL.appendingPathComponent("Gyro-Data")
+        let fileURL = directoryURL.appendingPathComponent("\(motionRecordData.id).txt")
+        guard let motionRecordJson = try? JSONEncoder().encode(motionRecordData),
+              let data = String(data: motionRecordJson, encoding: .utf8) else { return }
+
+        do {
+            try data.write(to: fileURL, atomically: true, encoding: .utf8)
+            completion(.success(()))
+        } catch {
+            print(error)
+            completion(.failure(error))
+        }
+    }
+
+    func loadFile(id: UUID, completion: @escaping (Result<MotionRecordDTO, Error>) -> Void) {
+        let filePath = directoryURL.appendingPathComponent("\(id).txt")
+
+        do {
+            let data = try Data(contentsOf: filePath)
+            let jsonData = try JSONDecoder().decode(MotionRecordDTO.self, from: data)
+            completion(.success(jsonData))
+        } catch {
+            print(error)
+            completion(.failure(error))
+        }
+    }
+
+    func deleteFile(id: UUID, completion: @escaping (Result<Void, Error>) -> Void) {
+        let filePath = directoryURL.appendingPathComponent("\(id).txt")
+        do {
+            try fileManager.removeItem(at: filePath)
+            completion(.success(()))
+        } catch {
+            print(error)
+            completion(.failure(error))
+        }
+    }
+
+
+    private func makeDirectory() {
+        do {
+            try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: false)
+        } catch {
+            print(error)
+        }
+    }
+}

--- a/GyroData/Data/FileStorage.swift
+++ b/GyroData/Data/FileStorage.swift
@@ -12,8 +12,9 @@ final class FileStorage {
     private lazy var documentURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
     private lazy var directoryURL = documentURL.appendingPathComponent("Gyro-Data")
 
+    static let shared = FileStorage()
 
-    init() {
+    private init() {
         if !UserDefaults.standard.bool(forKey: "isFirst") {
             UserDefaults.standard.set(true, forKey: "isFirst")
             makeDirectory()

--- a/GyroData/Data/MotionDataListStorage.swift
+++ b/GyroData/Data/MotionDataListStorage.swift
@@ -10,16 +10,22 @@ import CoreData
 final class MotionDataListStorage: MotionDataListStorageProtocol {
     private let coreDataStorage = CoreDataStorage.shared
 
-    func loadMotionRecords(page: Int, completion: @escaping (Result<[MotionRecord], Error>) -> Void) {
+    func loadMotionRecords(page: Int, completion: @escaping (Result<FetchMotionDataListResponse, Error>) -> Void) {
         let context = coreDataStorage.persistentContainer.viewContext
         DispatchQueue.global().async {
             do {
                 let request: NSFetchRequest = MotionRecordEntity.fetchRequest()
                 request.sortDescriptors = [NSSortDescriptor(key: #keyPath(MotionRecordEntity.startDate), ascending: false)]
                 request.fetchLimit = 10
+                request.fetchOffset = 10 * page
                 let result = try context.fetch(request).map { $0.toDomain() }
+                let response = FetchMotionDataListResponse(
+                    records: result,
+                    currentPage: page,
+                    hasNextPage: !result.isEmpty
+                )
 
-                completion(.success(result))
+                completion(.success(response))
             } catch {
                 completion(.failure(error))
             }

--- a/GyroData/Data/MotionDataListStorage.swift
+++ b/GyroData/Data/MotionDataListStorage.swift
@@ -19,10 +19,11 @@ final class MotionDataListStorage: MotionDataListStorageProtocol {
                 request.fetchLimit = 10
                 request.fetchOffset = 10 * page
                 let result = try context.fetch(request).map { $0.toDomain() }
+                print(result.count)
                 let response = FetchMotionDataListResponse(
                     records: result,
                     currentPage: page,
-                    hasNextPage: !result.isEmpty
+                    hasNextPage: result.count == 10
                 )
 
                 completion(.success(response))

--- a/GyroData/Data/MotionDataListStorage.swift
+++ b/GyroData/Data/MotionDataListStorage.swift
@@ -19,7 +19,6 @@ final class MotionDataListStorage: MotionDataListStorageProtocol {
                 request.fetchLimit = 10
                 request.fetchOffset = 10 * page
                 let result = try context.fetch(request).map { $0.toDomain() }
-                print(result.count)
                 let response = FetchMotionDataListResponse(
                     records: result,
                     currentPage: page,

--- a/GyroData/Data/MotionDataListStorage.swift
+++ b/GyroData/Data/MotionDataListStorage.swift
@@ -9,6 +9,7 @@ import CoreData
 
 final class MotionDataListStorage: MotionDataListStorageProtocol {
     private let coreDataStorage = CoreDataStorage.shared
+    private let fileStorage = FileStorage.shared
 
     func loadMotionRecords(page: Int, completion: @escaping (Result<FetchMotionDataListResponse, Error>) -> Void) {
         let context = coreDataStorage.persistentContainer.viewContext
@@ -39,11 +40,14 @@ final class MotionDataListStorage: MotionDataListStorageProtocol {
                 let request: NSFetchRequest = MotionRecordEntity.fetchRequest()
                 if let objectToDelete = try context.fetch(request).filter({ $0.motionRecordId == id }).first {
                     context.delete(objectToDelete)
-                    completion(.success(()))
                 }
                 try context.save()
             } catch {
                 completion(.failure(error))
+            }
+
+            self.fileStorage.deleteFile(id: id) { result in
+                completion(.success(()))
             }
         }
     }

--- a/GyroData/Data/MotionRecordDTO.swift
+++ b/GyroData/Data/MotionRecordDTO.swift
@@ -1,0 +1,43 @@
+//
+//  MotionRecordDTO.swift
+//  GyroData
+//
+//  Created by 천수현 on 2022/12/29.
+//
+
+import Foundation
+import CoreData
+
+struct MotionRecordDTO: Codable {
+    let id: UUID
+    let startDate: Date
+    let msInterval: Int
+    let motionMode: String
+    let coordinates: [CoordinateDTO]
+}
+
+extension MotionRecordDTO {
+    func toDomain() -> MotionRecord {
+        return MotionRecord(
+            id: id,
+            startDate: startDate,
+            msInterval: msInterval,
+            motionMode: motionMode == "acc" ? .accelerometer : .gyroscope,
+            coordinates: coordinates.map { Coordinate(x: $0.x, y: $0.y, z: $0.z) }
+        )
+    }
+}
+
+extension MotionRecordDTO {
+    func toEntity(in context: NSManagedObjectContext) -> MotionRecordEntity {
+        let motionRecordEntity = MotionRecordEntity(context: context)
+        motionRecordEntity.motionRecordId = id
+        motionRecordEntity.startDate = startDate
+        motionRecordEntity.msInterval = Int64(msInterval)
+        motionRecordEntity.motionMode = motionMode
+        motionRecordEntity.coordinates = coordinates.map {
+            return [$0.x, $0.y, $0.z]
+        }
+        return motionRecordEntity
+    }
+}

--- a/GyroData/Data/MotionRecordDTO.swift
+++ b/GyroData/Data/MotionRecordDTO.swift
@@ -41,3 +41,14 @@ extension MotionRecordDTO {
         return motionRecordEntity
     }
 }
+
+extension MotionRecord {
+    func toDTO() -> MotionRecordDTO {
+        return MotionRecordDTO(
+            id: id,
+            startDate: startDate,
+            msInterval: msInterval,
+            motionMode: motionMode == .accelerometer ? "acc" : "gyro" ,
+            coordinates: coordinates.map { return CoordinateDTO(x: $0.x, y: $0.y, z: $0.z) })
+    }
+}

--- a/GyroData/Data/MotionRecordingStorage.swift
+++ b/GyroData/Data/MotionRecordingStorage.swift
@@ -9,6 +9,7 @@ import Foundation
 
 final class MotionRecordingStorage: MotionRecordingStorageProtocol {
     private let coreDataStorage = CoreDataStorage.shared
+    private let fileStorage = FileStorage.shared
 
     func saveRecord(record: MotionRecord, completion: @escaping (Result<Void, Error>) -> Void) {
         let context = coreDataStorage.persistentContainer.viewContext
@@ -24,6 +25,16 @@ final class MotionRecordingStorage: MotionRecordingStorageProtocol {
                 try context.save()
             } catch {
                 print(error)
+                completion(.failure(error))
+            }
+
+            self.fileStorage.saveFile(motionRecordData: record.toDTO()) { result in
+                switch result {
+                case .success:
+                    completion(.success(()))
+                case .failure(let error):
+                    completion(.failure(error))
+                }
             }
         }
     }

--- a/GyroData/Data/MotionReplayStorage.swift
+++ b/GyroData/Data/MotionReplayStorage.swift
@@ -1,0 +1,23 @@
+//
+//  MotionReplayStorage.swift
+//  GyroData
+//
+//  Created by 천수현 on 2022/12/30.
+//
+
+import Foundation
+
+final class MotionReplayStorage: MotionReplayStorageProtocol {
+    private let fileStorage = FileStorage.shared
+
+    func loadMotionRecord(id: UUID, completion: @escaping (Result<MotionRecord, Error>) -> Void) {
+        fileStorage.loadFile(id: id) { result in
+            switch result {
+            case .success(let record):
+                completion(.success(record.toDomain()))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+}

--- a/GyroData/Domain/StorageInterfaces/MotionDataListStorageProtocol.swift
+++ b/GyroData/Domain/StorageInterfaces/MotionDataListStorageProtocol.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 protocol MotionDataListStorageProtocol {
-    func loadMotionRecords(page: Int, completion: @escaping (Result<[MotionRecord], Error>) -> Void)
+    func loadMotionRecords(page: Int, completion: @escaping (Result<FetchMotionDataListResponse, Error>) -> Void)
     func deleteRecord(id: UUID, completion: @escaping (Result<Void, Error>) -> Void)
 }

--- a/GyroData/Domain/StorageInterfaces/MotionReplayStorageProtocol.swift
+++ b/GyroData/Domain/StorageInterfaces/MotionReplayStorageProtocol.swift
@@ -1,0 +1,12 @@
+//
+//  MotionReplayStorageProtocol.swift
+//  GyroData
+//
+//  Created by 천수현 on 2022/12/30.
+//
+
+import Foundation
+
+protocol MotionReplayStorageProtocol {
+    func loadMotionRecord(id: UUID, completion: @escaping (Result<MotionRecord, Error>) -> Void)
+}

--- a/GyroData/Domain/UseCases/FetchMotionDataListUseCase.swift
+++ b/GyroData/Domain/UseCases/FetchMotionDataListUseCase.swift
@@ -14,14 +14,20 @@ final class FetchMotionDataListUseCase {
         self.motionDataListStorage = motionDataListStorage
     }
 
-    func execute(page: Int, completion: @escaping (Result<[MotionRecord], Error>) -> Void) {
+    func execute(page: Int, completion: @escaping (Result<FetchMotionDataListResponse, Error>) -> Void) {
         motionDataListStorage.loadMotionRecords(page: page) { result in
             switch result {
-            case .success(let records):
-                completion(.success(records))
+            case .success(let response):
+                completion(.success(response))
             case .failure(let error):
                 completion(.failure(error))
             }
         }
     }
+}
+
+struct FetchMotionDataListResponse {
+    let records: [MotionRecord]
+    let currentPage: Int
+    let hasNextPage: Bool
 }

--- a/GyroData/Domain/UseCases/FetchMotionDataUseCase.swift
+++ b/GyroData/Domain/UseCases/FetchMotionDataUseCase.swift
@@ -1,0 +1,23 @@
+//
+//  FetchMotionDataUseCase.swift
+//  GyroData
+//
+//  Created by 천수현 on 2022/12/30.
+//
+
+import Foundation
+
+final class FetchMotionDataUseCase {
+    private let storage = MotionReplayStorage()
+
+    func execute(id: UUID, completion: @escaping (Result<MotionRecord, Error>) -> Void) {
+        storage.loadMotionRecord(id: id) { result in
+            switch result {
+            case .success(let record):
+                completion(.success(record))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+}

--- a/GyroData/Info.plist
+++ b/GyroData/Info.plist
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd%22%3E">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-    <dict>
-        <key>UIApplicationSceneManifest</key>
-        <dict>
-            <key>UISceneConfigurations</key>
-            <dict/>
-        </dict>
-    </dict>
+<dict>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
+	<key>UIFileSharingEnabled</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UISceneConfigurations</key>
+		<dict/>
+	</dict>
+</dict>
 </plist>

--- a/GyroData/Presentation/MotionDataList/MotionDataListViewController.swift
+++ b/GyroData/Presentation/MotionDataList/MotionDataListViewController.swift
@@ -107,4 +107,12 @@ extension MotionDataListViewController: UITableViewDelegate {
             , animated: true
         )
     }
+
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        if indexPath.row > viewModel.records.count - 3 {
+            viewModel.fetchNextPage { indexPaths in
+                tableView.insertRows(at: indexPaths, with: .automatic)
+            }
+        }
+    }
 }

--- a/GyroData/Presentation/MotionDataList/MotionDataListViewModel.swift
+++ b/GyroData/Presentation/MotionDataList/MotionDataListViewModel.swift
@@ -31,9 +31,9 @@ final class MotionDataListViewModel {
     func fetchNextPage(completion: @escaping ([IndexPath]) -> Void) {
         if !isFetching && hasNextPage {
             isFetching = true
-            fetchMotionDataList(page: pageToLoad) { [weak self] in
+            fetchMotionDataList(page: pageToLoad) { [weak self] fetchedCount in
                 guard let self = self else { return }
-                completion((self.records.count - 10 ... self.records.count - 1).map {
+                completion((self.records.count - fetchedCount ... self.records.endIndex).map {
                     return IndexPath(row: $0, section: 0)
                 })
                 self.isFetching = false
@@ -44,9 +44,10 @@ final class MotionDataListViewModel {
     private func initializeViewModel() {
         hasNextPage = true
         pageToLoad = 0
+        records.removeAll()
     }
 
-    private func fetchMotionDataList(page: Int, completion: (() -> Void)? = nil) {
+    private func fetchMotionDataList(page: Int, completion: ((Int) -> Void)? = nil) {
         isFetching = true
         fetchMotionDataListUseCase.execute(page: page) { [weak self] result in
             guard let self = self else { return }
@@ -57,6 +58,7 @@ final class MotionDataListViewModel {
                 self.hasNextPage = response.hasNextPage
                 self.isFetching = false
                 self.reloadData?()
+                completion?(response.records.count)
             case .failure(let error):
                 print(error)
             }

--- a/GyroData/Presentation/MotionDataList/MotionDataListViewModel.swift
+++ b/GyroData/Presentation/MotionDataList/MotionDataListViewModel.swift
@@ -11,9 +11,11 @@ final class MotionDataListViewModel {
     private let fetchMotionDataListUseCase = FetchMotionDataListUseCase()
     private let deleteMotionDataListUseCase = DeleteMotionDataUseCase()
     private var pageToLoad = 0
+    var hasNextPage = true
     var reloadData: (() -> Void)?
 
     func viewWillAppear() {
+        initializeViewModel()
         fetchMotionDataList(page: pageToLoad)
     }
 
@@ -25,12 +27,19 @@ final class MotionDataListViewModel {
         }
     }
 
+    private func initializeViewModel() {
+        hasNextPage = true
+        pageToLoad = 0
+    }
+
     private func fetchMotionDataList(page: Int) {
         fetchMotionDataListUseCase.execute(page: page) { [weak self] result in
             guard let self = self else { return }
             switch result {
-            case .success(let records):
-                self.records = records
+            case .success(let response):
+                self.records = response.records
+                self.pageToLoad = response.currentPage + 1
+                self.hasNextPage = response.hasNextPage
                 self.reloadData?()
             case .failure(let error):
                 print(error)

--- a/GyroData/Presentation/MotionDataList/MotionDataListViewModel.swift
+++ b/GyroData/Presentation/MotionDataList/MotionDataListViewModel.swift
@@ -13,6 +13,7 @@ final class MotionDataListViewModel {
     private var pageToLoad = 0
     var hasNextPage = true
     var reloadData: (() -> Void)?
+    var isFetching = false
 
     func viewWillAppear() {
         initializeViewModel()
@@ -27,19 +28,34 @@ final class MotionDataListViewModel {
         }
     }
 
+    func fetchNextPage(completion: @escaping ([IndexPath]) -> Void) {
+        if !isFetching && hasNextPage {
+            isFetching = true
+            fetchMotionDataList(page: pageToLoad) { [weak self] in
+                guard let self = self else { return }
+                completion((self.records.count - 10 ... self.records.count - 1).map {
+                    return IndexPath(row: $0, section: 0)
+                })
+                self.isFetching = false
+            }
+        }
+    }
+
     private func initializeViewModel() {
         hasNextPage = true
         pageToLoad = 0
     }
 
-    private func fetchMotionDataList(page: Int) {
+    private func fetchMotionDataList(page: Int, completion: (() -> Void)? = nil) {
+        isFetching = true
         fetchMotionDataListUseCase.execute(page: page) { [weak self] result in
             guard let self = self else { return }
             switch result {
             case .success(let response):
-                self.records = response.records
+                self.records += response.records
                 self.pageToLoad = response.currentPage + 1
                 self.hasNextPage = response.hasNextPage
+                self.isFetching = false
                 self.reloadData?()
             case .failure(let error):
                 print(error)

--- a/GyroData/Presentation/MotionReplay/MotionReplayViewController.swift
+++ b/GyroData/Presentation/MotionReplay/MotionReplayViewController.swift
@@ -52,6 +52,10 @@ final class MotionReplayViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    deinit {
+        timer.resume()
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .systemBackground

--- a/GyroData/Presentation/MotionReplay/MotionReplayViewController.swift
+++ b/GyroData/Presentation/MotionReplay/MotionReplayViewController.swift
@@ -37,7 +37,7 @@ final class MotionReplayViewController: UIViewController {
     private var timer = Timer()
 
     init(replayType: ReplayType, motionRecord: MotionRecord) {
-        viewModel = MotionReplayViewModel(replayType: replayType, record: motionRecord)
+        viewModel = MotionReplayViewModel(replayType: replayType, id: motionRecord.id)
         graphView = GraphView(xScale: CGFloat(motionRecord.coordinates.count))
         super.init(nibName: nil, bundle: nil)
     }
@@ -58,9 +58,12 @@ final class MotionReplayViewController: UIViewController {
     }
 
     override func viewDidLayoutSubviews() {
-        if viewModel.replayType == .view && !viewModel.isDrawingGraphView {
-            viewModel.isDrawingGraphView = true
-            showFinishedGraphView()
+        viewModel.fetchMotionData { [weak self] in
+            guard let self = self else { return }
+            if self.viewModel.replayType == .view && !self.viewModel.isDrawingGraphView {
+                self.viewModel.isDrawingGraphView = true
+                self.showFinishedGraphView()
+            }
         }
     }
 
@@ -99,7 +102,7 @@ final class MotionReplayViewController: UIViewController {
     }
 
     private func setUpLabelContents() {
-        dateLabel.text = viewModel?.record.startDate.toString()
+        dateLabel.text = viewModel?.record?.startDate.toString()
         typeLabel.text = viewModel?.replayType.name
     }
 
@@ -110,8 +113,9 @@ final class MotionReplayViewController: UIViewController {
 
     private func playGraphView() {
         graphView.reset()
-        let record = viewModel.record
+        guard let record = viewModel.record else { return }
         viewModel.isDrawingGraphView = true
+
         var index = 0
         var time: Double = 0
 
@@ -141,7 +145,7 @@ final class MotionReplayViewController: UIViewController {
 
     @objc
     private func playButtonTapped(_ sender: UIButton) {
-        if viewModel.playButtonState == .play {
+        if viewModel.playButtonState == .play && viewModel.record != nil {
             viewModel.playButtonState = .stop
             playButton.setImage(UIImage(systemName: "stop.fill"), for: .normal)
             playGraphView()

--- a/GyroData/Presentation/MotionReplay/MotionReplayViewModel.swift
+++ b/GyroData/Presentation/MotionReplay/MotionReplayViewModel.swift
@@ -10,7 +10,7 @@ import Foundation
 final class MotionReplayViewModel {
     let replayType: ReplayType
     let record: MotionRecord
-    var didGraphViewStartedDrawing = false
+    var isDrawingGraphView = false
     var playButtonState: PlayButtonState = .play
 
     init(replayType: ReplayType, record: MotionRecord) {

--- a/GyroData/Presentation/MotionReplay/MotionReplayViewModel.swift
+++ b/GyroData/Presentation/MotionReplay/MotionReplayViewModel.swift
@@ -9,13 +9,27 @@ import Foundation
 
 final class MotionReplayViewModel {
     let replayType: ReplayType
-    let record: MotionRecord
+    let recordId: UUID
+    var record: MotionRecord?
     var isDrawingGraphView = false
     var playButtonState: PlayButtonState = .play
+    private let fetchMotionDataUseCase = FetchMotionDataUseCase()
 
-    init(replayType: ReplayType, record: MotionRecord) {
+    init(replayType: ReplayType, id: UUID) {
         self.replayType = replayType
-        self.record = record
+        self.recordId = id
+    }
+
+    func fetchMotionData(completion: @escaping () -> Void) {
+        fetchMotionDataUseCase.execute(id: recordId) { result in
+            switch result {
+            case .success(let record):
+                self.record = record
+                completion()
+            case .failure(let error):
+                print(error)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## PR 요약
- FileManager를 통해 데이터를 save, load, delete하는 로직을 제작하였습니다.
- UseCase가 Storage를 사용하도록 하는 방법은 이전과 동일하며, 화면별로 분할된 Storage에서 FileStorage와 CoreDataStorage를 모두 사용하는 형식으로 제작했습니다.

## Screenshot
**동작화면**
<img src = "https://user-images.githubusercontent.com/67148595/210043057-cf5bf050-6ba7-4cbc-94e9-021506d9034b.gif" width="50%" height="height 50%">

**json 형태로 저장된 파일**
<img width="688" alt="image" src="https://user-images.githubusercontent.com/67148595/210043168-786976d1-c1ce-436f-8a52-560f3b86d9c9.png">

## 변경사항
- MotionDataList화면에서 다음 page를 가져오는 부분의 index 설정 로직이 개선되었습니다


#### Linked Issue

close #18 

